### PR TITLE
allow not using dune-site when you provide your own config

### DIFF
--- a/src/camomile.ml
+++ b/src/camomile.ml
@@ -20,120 +20,13 @@ module Private = struct
   module XArray = XArray
 end
 
+module Config = struct
+  include Config
+  module Default = ConfigImpl
+end
+
 module DefaultConfig = Config.Default
 
-module type Type = sig
-  module OOChannel : module type of OOChannel
-  module USet : module type of USet
-  module UChar : module type of UChar
-  module UMap : module type of UMap
-  module UCharTbl : module type of UCharTbl
-  module UnicodeString : module type of UnicodeString
-  module UText : module type of UText
-  module XString : module type of XString
-  module SubText : module type of SubText
-  module ULine : module type of ULine
-  module Locale : module type of Locale
-  module CharEncoding : CharEncoding.Interface
-  module UTF8 : module type of UTF8
-  module UTF16 : module type of UTF16
-  module UCS4 : module type of UCS4
-  module UPervasives : module type of UPervasives
-  module URe : module type of URe
-  module UCharInfo : UCharInfo.Type
-
-  module UNF : sig
-    module type Type = UNF.Type
-
-    module Make (Text : UnicodeString.Type) :
-      Type with type text = Text.t and type index = Text.index
-  end
-
-  module UCol : sig
-    (** How variables are handled *)
-    type variable_option =
-      [ `Blanked | `Non_ignorable | `Shifted | `Shift_Trimmed ]
-
-    (** Strength of comparison.  For European languages, each strength
-        roughly means as
-        `Primary : Ignore accents and case
-        `Secondary : Ignore case but accents are counted in.
-        `Tertiary : Accents and case are counted in.
-        For the case of `Shifted, `Shift_Trimmed, there is the fourth strength.
-        `Quaternary : Variables such as - (hyphen) are counted in. *)
-    type precision = [ `Primary | `Secondary | `Tertiary | `Quaternary ]
-
-    module type Type = UCol.Type
-
-    module Make (Text : UnicodeString.Type) :
-      Type with type text = Text.t and type index = Text.index
-  end
-
-  module CaseMap : sig
-    module type Type = CaseMap.Type
-
-    module Make (Text : UnicodeString.Type) : Type with type text = Text.t
-  end
-
-  module UReStr : UReStr.Interface
-
-  module StringPrep : sig
-    module type Type = StringPrep.Type
-
-    module Make (Text : UnicodeString.Type) : Type with type text = Text.t
-  end
-end
-
-module Make (Config : Config.Type) = struct
-  module OOChannel = OOChannel
-  module UChar = UChar
-  module USet = USet
-  module UMap = UMap
-  module UCharTbl = UCharTbl
-  module UnicodeString = UnicodeString
-  module UText = UText
-  module XString = XString
-  module SubText = SubText
-  module ULine = ULine
-  module Locale = Locale
-  module CharEncoding = CharEncoding.Configure (Config)
-  module UTF8 = UTF8
-  module UTF16 = UTF16
-  module UCS4 = UCS4
-  module UPervasives = UPervasives
-  module URe = URe
-  module UCharInfo = UCharInfo.Make (Config)
-
-  module UNF = struct
-    module type Type = UNF.Type
-
-    module Make = UNF.Make (Config)
-  end
-
-  module UCol = struct
-    type variable_option =
-      [ `Blanked | `Non_ignorable | `Shifted | `Shift_Trimmed ]
-
-    type precision = [ `Primary | `Secondary | `Tertiary | `Quaternary ]
-
-    module type Type = UCol.Type
-
-    module Make = UCol.Make (Config)
-  end
-
-  module CaseMap = struct
-    module type Type = CaseMap.Type
-
-    module Make = CaseMap.Make (Config)
-  end
-
-  module UReStr = UReStr.Configure (Config)
-
-  module StringPrep = struct
-    module type Type = StringPrep.Type
-
-    module Make = StringPrep.Make (Config)
-  end
-end
+include Functor
 
 include Make (Config.Default)

--- a/src/config.ml
+++ b/src/config.ml
@@ -1,2 +1,1 @@
 include ConfigBase
-module Default = ConfigImpl

--- a/src/config.mli
+++ b/src/config.mli
@@ -12,5 +12,3 @@ module type Type = sig
   (** Directory of compiled locale data *)
   val localedir : string
 end
-
-module Default : Type

--- a/src/dune
+++ b/src/dune
@@ -24,11 +24,11 @@
 (library
  (name camomileLib)
  (public_name camomile.lib)
- (libraries dune-site bigarray camlp-streams)
- (modules :standard \ camomile))
+ (libraries bigarray camlp-streams)
+ (modules :standard \ camomile configImpl sites))
 
 (library
  (name camomile)
  (public_name camomile)
- (libraries camomileLib)
- (modules camomile))
+ (libraries camomileLib dune-site)
+ (modules camomile configImpl sites))

--- a/src/functor.ml
+++ b/src/functor.ml
@@ -1,0 +1,114 @@
+
+module type Type = sig
+  module OOChannel : module type of OOChannel
+  module USet : module type of USet
+  module UChar : module type of UChar
+  module UMap : module type of UMap
+  module UCharTbl : module type of UCharTbl
+  module UnicodeString : module type of UnicodeString
+  module UText : module type of UText
+  module XString : module type of XString
+  module SubText : module type of SubText
+  module ULine : module type of ULine
+  module Locale : module type of Locale
+  module CharEncoding : CharEncoding.Interface
+  module UTF8 : module type of UTF8
+  module UTF16 : module type of UTF16
+  module UCS4 : module type of UCS4
+  module UPervasives : module type of UPervasives
+  module URe : module type of URe
+  module UCharInfo : UCharInfo.Type
+
+  module UNF : sig
+    module type Type = UNF.Type
+
+    module Make (Text : UnicodeString.Type) :
+      Type with type text = Text.t and type index = Text.index
+  end
+
+  module UCol : sig
+    (** How variables are handled *)
+    type variable_option =
+      [ `Blanked | `Non_ignorable | `Shifted | `Shift_Trimmed ]
+
+    (** Strength of comparison.  For European languages, each strength
+        roughly means as
+        `Primary : Ignore accents and case
+        `Secondary : Ignore case but accents are counted in.
+        `Tertiary : Accents and case are counted in.
+        For the case of `Shifted, `Shift_Trimmed, there is the fourth strength.
+        `Quaternary : Variables such as - (hyphen) are counted in. *)
+    type precision = [ `Primary | `Secondary | `Tertiary | `Quaternary ]
+
+    module type Type = UCol.Type
+
+    module Make (Text : UnicodeString.Type) :
+      Type with type text = Text.t and type index = Text.index
+  end
+
+  module CaseMap : sig
+    module type Type = CaseMap.Type
+
+    module Make (Text : UnicodeString.Type) : Type with type text = Text.t
+  end
+
+  module UReStr : UReStr.Interface
+
+  module StringPrep : sig
+    module type Type = StringPrep.Type
+
+    module Make (Text : UnicodeString.Type) : Type with type text = Text.t
+  end
+end
+
+module Make (Config : Config.Type) = struct
+  module OOChannel = OOChannel
+  module UChar = UChar
+  module USet = USet
+  module UMap = UMap
+  module UCharTbl = UCharTbl
+  module UnicodeString = UnicodeString
+  module UText = UText
+  module XString = XString
+  module SubText = SubText
+  module ULine = ULine
+  module Locale = Locale
+  module CharEncoding = CharEncoding.Configure (Config)
+  module UTF8 = UTF8
+  module UTF16 = UTF16
+  module UCS4 = UCS4
+  module UPervasives = UPervasives
+  module URe = URe
+  module UCharInfo = UCharInfo.Make (Config)
+
+  module UNF = struct
+    module type Type = UNF.Type
+
+    module Make = UNF.Make (Config)
+  end
+
+  module UCol = struct
+    type variable_option =
+      [ `Blanked | `Non_ignorable | `Shifted | `Shift_Trimmed ]
+
+    type precision = [ `Primary | `Secondary | `Tertiary | `Quaternary ]
+
+    module type Type = UCol.Type
+
+    module Make = UCol.Make (Config)
+  end
+
+  module CaseMap = struct
+    module type Type = CaseMap.Type
+
+    module Make = CaseMap.Make (Config)
+  end
+
+  module UReStr = UReStr.Configure (Config)
+
+  module StringPrep = struct
+    module type Type = StringPrep.Type
+
+    module Make = StringPrep.Make (Config)
+  end
+end


### PR DESCRIPTION
dune-site [forces](https://github.com/ocaml/dune/blob/605f300da56f0daf8e021001a6d1f3aecb0f30da/src/dune_rules/link_time_code_gen.ml#L325) any dune build executable linked with it to use -linkall, which can be a very bad thing depending on what libraries it is using: if you want to use a single module in an unrelated lib, you pull in everything in that lib.

However, most of the code in camomile actually does not need dune-site: Its just the application of the functor that does, for all the other code the config is abstract.

This PR makes it so only `camomile` is linked with `dune-site` and `camomile.lib` is not. The interface of `camomile` is exactly the same, but the one in `camomile.lib` changes:

- There is a new module `Functor` with the `Type` and `Make` module that used to only be in `camomile`
- The `Config` module lost its `Default` field (this is still available in `camomile`)  