### PR TITLE
Fix path handling from dune variable

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+unreleased
+----------
+
+- Fix charmap generation with dune 3.24, which expands `%{deps}` to a path
+  with a directory component (#13).
+
 2.0.0 (2023-03-20)
 ------------------
 

--- a/src/tools/camomilecharmap.ml
+++ b/src/tools/camomilecharmap.ml
@@ -46,7 +46,7 @@ let parse_arg () =
   Arg.parse
     [("-d", Arg.String (( := ) dir), "[directory]\toutputpath")]
     (fun s ->
-      if !file <> None then failwith "Too many arguments" else file := Some (Filename.basename s))
+      if !file <> None then failwith "Too many arguments" else file := Some s)
     helptext;
   (!file, !dir)
 
@@ -77,7 +77,9 @@ let begin_with s s' =
     with Break -> false)
 
 let parse_header file inchan =
-  let codeset_name = ref file in
+  (* Charmaps without a <code_set_name> header are named after the input file.
+     Dune passes it as a path, so strip the directory. *)
+  let codeset_name = ref (Option.map Filename.basename file) in
   let aliases = ref [] in
   let unread_line = ref None in
   try

--- a/src/tools/camomilecharmap.ml
+++ b/src/tools/camomilecharmap.ml
@@ -46,7 +46,7 @@ let parse_arg () =
   Arg.parse
     [("-d", Arg.String (( := ) dir), "[directory]\toutputpath")]
     (fun s ->
-      if !file <> None then failwith "Too many arguments" else file := Some s)
+      if !file <> None then failwith "Too many arguments" else file := Some (Filename.basename s))
     helptext;
   (!file, !dir)
 


### PR DESCRIPTION
Dune `deps` variables are expanded to paths. The representation of the paths has changed with https://github.com/ocaml/dune/pull/15156, causing camomile to fail on the pending dune 3.24. But in general this has always been a path, so if we only want the basename of the path in a stable form, we need to derive that explicitly.