### PR TITLE
add missing header to PT, fixes compilation under dune 3.24

### DIFF
--- a/compat/camomileLibrary.mli
+++ b/compat/camomileLibrary.mli
@@ -1,4 +1,7 @@
-include Camomile
+[@@@ocaml.deprecated
+"this module is deprecated, please update to the most recent camomile API"]
+
+include module type of Camomile
 module CharEncoding = CamomileLib.CharEncoding
 module UCharInfo = CamomileLib.UCharInfo
 module UNF = CamomileLib.UNF
@@ -7,6 +10,7 @@ module CaseMap = CamomileLib.CaseMap
 module UReStr = CamomileLib.UReStr
 module StringPrep = CamomileLib.StringPrep
 
-module ConfigInt = struct
+module ConfigInt : sig
   module type Type = CamomileLib.Config.Type
 end
+

--- a/src/charmaps/sources/EBCDIC-PT
+++ b/src/charmaps/sources/EBCDIC-PT
@@ -1,3 +1,9 @@
+<code_set_name> EBCDIC-PT
+<comment_char> %
+<escape_char> /
+% version: 1.0
+
+CHARMAP
 <U0000>     /x00         NULL (NUL)
 <U0001>     /x01         START OF HEADING (SOH)
 <U0002>     /x02         START OF TEXT (STX)

--- a/src/charmaps/sources/EBCDIC-PT
+++ b/src/charmaps/sources/EBCDIC-PT
@@ -2,6 +2,7 @@
 <comment_char> %
 <escape_char> /
 % version: 1.0
+%  source: IBM 3270 Char Set Ref Ch 10, GA27-2837-9, April 1987
 
 CHARMAP
 <U0000>     /x00         NULL (NUL)


### PR DESCRIPTION
I don't know why the PR fixes the build

It was the only EBCDIC file without a header and it was the file where the build failed so I just took a shot

Maybe dune passes a different set of default flags to ocamlyacc/ocamllex?

---------------

The second commit is just to address a warning about the deprecation warning being misplaced (it needs to be in the mli)